### PR TITLE
🌓 Theme Toast

### DIFF
--- a/src/components/info/ModalComp.vue
+++ b/src/components/info/ModalComp.vue
@@ -112,7 +112,7 @@ export default defineComponent({
 
       <div class="modal__body">
         <component
-          :is="{ ...modal.component }"
+          :is="modal.component"
           :modal-id="modal.id"
           :params="modal.props"
         />

--- a/src/components/info/ToastComp.vue
+++ b/src/components/info/ToastComp.vue
@@ -22,8 +22,9 @@ export default defineComponent({
 
   setup() {
     const elementRef = ref(null);
+    const timer = ref<ReturnType<typeof setTimeout> | null>(null);
 
-    return { elementRef };
+    return { elementRef, timer };
   },
 
   computed: {
@@ -55,9 +56,15 @@ export default defineComponent({
 
     DOMHelper.focus(".toast__action button", elementRef as HTMLElement);
 
-    setTimeout(() => {
+    this.timer = setTimeout(() => {
       this.onClose();
     }, 3000);
+  },
+
+  beforeUnmount(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+    }
   },
 
   methods: {


### PR DESCRIPTION
Toggling the theme rapidly caused the active toast to not be overridden by the incoming one. Two related issues combined to produce this:

1. __Stale `setTimeout` in `ToastComp`__ — the auto-dismiss timer started in `mounted()` was never cancelled when the component was unmounted. Every time a toast was replaced, the previous instance's timer kept running. Since `mounted()` re-runs on each (re)mount, accumulated ghost timers would all fire against the same live `modalId`, causing `ModalHelper.close()` to be called multiple times on the same toast — dismissing it earlier than expected and leaving the impression the new toast never replaced the old one.

2. __`{ ...modal.component }` spread in `ModalComp`__ — spreading the component definition on every render produced a new object reference for `:is` on each re-render. Because `ModalComp` subscribes to `appStore.theme` (via `isDark` / `closeType`), every theme change re-rendered `ModalComp`, changed the `:is` reference, and caused Vue to fully unmount and remount the inner component. This meant a fresh `mounted()` — and a fresh `setTimeout` — was started for a toast that was supposed to stay mounted, compounding the stale-timer problem described above.

### Changes

__`src/components/info/ToastComp.vue`__

- Stored the `setTimeout` ID in a `timer` ref returned from `setup()`
- Added a `beforeUnmount()` hook that calls `clearTimeout(this.timer)`, ensuring the auto-dismiss callback is never invoked after the component has been replaced

__`src/components/info/ModalComp.vue`__

- Replaced `:is="{ ...modal.component }"` with `:is="modal.component"`
- `modal.component` is already the resolved component definition object; spreading it served no purpose and created a new reference on every render, triggering unnecessary full remounts of the hosted component

### Testing

1. Open the app and toggle the theme button once — a toast should appear.
2. While the toast is still visible, toggle the theme again — the previous toast should immediately disappear and the new toast should appear in its place.
3. Repeat rapidly (5+ times) — each toggle should replace the prior toast cleanly with no duplicate or premature dismissals.
4. Open a source-edit dialog, then toggle the theme — the dialog should remain open and not remount (no form state loss).

Fixes #172