### PR TITLE
🌓 Auto Theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "run-p type-check \"build-only {@}\" --",
     "lint": "pnpm dx lint",
     "lint:fix": "pnpm dx lint --fix",
+    "check": "pnpm lint && pnpm build",
     "build-only": "vite build",
     "dev": "vite",
     "format": "prettier --write src/",

--- a/src/components/controls/ButtonComp.vue
+++ b/src/components/controls/ButtonComp.vue
@@ -1,12 +1,14 @@
 <script lang="ts">
 import type { PropType } from "vue";
-import type { TButtonType } from "@/utils/types/composition/buttonType.type";
+import type { Theme } from "@/utils/enums/theme.enum";
 
+import type { TButtonType } from "@/utils/types/composition/buttonType.type";
 import { mapState } from "pinia";
 import { defineComponent } from "vue";
+
 import { useAppStore } from "@/state/stores/app.store";
 
-import { Theme } from "@/utils/enums/theme.enum";
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -37,14 +39,22 @@ export default defineComponent({
 
     /**
      * @description
+     * Checks if dark theme is on
+     *
+     * @returns Whether the dark theme is active
+     */
+    isDark(): boolean {
+      return ThemeHelper.isDark(this.theme as Theme);
+    },
+
+    /**
+     * @description
      * The theme class of the button
      *
      * @returns The theme CSS class string
      */
     themeClass(): string {
-      const theme = this.theme === Theme.Light ? "light" : "dark";
-
-      return `button--${theme}`;
+      return this.isDark ? "button--dark" : "button--light";
     },
   },
 });

--- a/src/components/controls/InputComp.vue
+++ b/src/components/controls/InputComp.vue
@@ -1,9 +1,12 @@
 <script lang="ts">
+import type { Theme } from "@/utils/enums/theme.enum";
 import { mapState } from "pinia";
+
 import { defineComponent } from "vue";
 
 import { useAppStore } from "@/state/stores/app.store";
-import { Theme } from "@/utils/enums/theme.enum";
+
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -37,7 +40,7 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
   },
 

--- a/src/components/controls/RangeComp.vue
+++ b/src/components/controls/RangeComp.vue
@@ -1,9 +1,12 @@
 <script lang="ts">
+import type { Theme } from "@/utils/enums/theme.enum";
 import { mapState } from "pinia";
+
 import { defineComponent, ref } from "vue";
 
 import { useAppStore } from "@/state/stores/app.store";
-import { Theme } from "@/utils/enums/theme.enum";
+
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -59,7 +62,7 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
   },
 

--- a/src/components/controls/SelectComp.vue
+++ b/src/components/controls/SelectComp.vue
@@ -1,12 +1,15 @@
 <script lang="ts">
 import type { PropType } from "vue";
-import type { TOption } from "@/utils/types/composition/option.type";
+import type { Theme } from "@/utils/enums/theme.enum";
 
+import type { TOption } from "@/utils/types/composition/option.type";
 import { mapState } from "pinia";
+
 import { defineComponent } from "vue";
 
 import { useAppStore } from "@/state/stores/app.store";
-import { Theme } from "@/utils/enums/theme.enum";
+
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -32,7 +35,7 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
   },
 

--- a/src/components/info/ModalComp.vue
+++ b/src/components/info/ModalComp.vue
@@ -1,16 +1,18 @@
 <script lang="ts">
 import type { PropType } from "vue";
-import type { TComponent } from "@/utils/types/composition/component.type";
+import type { Theme } from "@/utils/enums/theme.enum";
 
+import type { TComponent } from "@/utils/types/composition/component.type";
 import type { TModal } from "@/utils/types/composition/modal.type";
 import { mapState } from "pinia";
-import { defineComponent } from "vue";
 
+import { defineComponent } from "vue";
 import { useAppStore } from "@/state/stores/app.store";
+
 import { ModalAlignment } from "@/utils/enums/modalAlignment.enum";
 
-import { Theme } from "@/utils/enums/theme.enum";
 import { ModalHelper } from "@/utils/helpers/modal.helper";
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -40,7 +42,7 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
 
     /**

--- a/src/components/info/MoreComp.vue
+++ b/src/components/info/MoreComp.vue
@@ -1,10 +1,13 @@
 <script lang="ts">
+import type { Theme } from "@/utils/enums/theme.enum";
 import { mapState } from "pinia";
+
+
 import { defineComponent, ref } from "vue";
 
-
 import { useAppStore } from "@/state/stores/app.store";
-import { Theme } from "@/utils/enums/theme.enum";
+
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -41,7 +44,7 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
   },
 

--- a/src/components/info/ShortcutsComp.vue
+++ b/src/components/info/ShortcutsComp.vue
@@ -1,11 +1,13 @@
 <script lang="ts">
+import type { Theme } from "@/utils/enums/theme.enum";
 import { mapState } from "pinia";
+
 import { defineComponent, ref } from "vue";
 
 import { useAppStore } from "@/state/stores/app.store";
 
-import { Theme } from "@/utils/enums/theme.enum";
 import { DOMHelper } from "@/utils/helpers/dom.helper";
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -31,7 +33,7 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
   },
 

--- a/src/components/info/ToastComp.vue
+++ b/src/components/info/ToastComp.vue
@@ -1,15 +1,17 @@
 <script lang="ts">
 import type { PropType } from "vue";
-import type { TToast } from "@/utils/types/composition/toast.type";
+import type { Theme } from "@/utils/enums/theme.enum";
 
+import type { TToast } from "@/utils/types/composition/toast.type";
 import { mapState } from "pinia";
 import { defineComponent, ref } from "vue";
+
 import { useAppStore } from "@/state/stores/app.store";
 
-import { Theme } from "@/utils/enums/theme.enum";
 import { DOMHelper } from "@/utils/helpers/dom.helper";
-
 import { ModalHelper } from "@/utils/helpers/modal.helper";
+
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -37,7 +39,7 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
 
     /**

--- a/src/components/layout/ControlsComp.vue
+++ b/src/components/layout/ControlsComp.vue
@@ -1,12 +1,14 @@
 <script lang="ts">
+import type { Theme } from "@/utils/enums/theme.enum";
 import { mapActions, mapState } from "pinia";
-import { defineComponent } from "vue";
 
+import { defineComponent } from "vue";
 import { useAppStore } from "@/state/stores/app.store";
+
 import { useSourcesStore } from "@/state/stores/sources.store";
 
-import { Theme } from "@/utils/enums/theme.enum";
 import { getVolumeIcon } from "@/utils/helpers/fontawesome.helper";
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -88,8 +90,9 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
+
   },
 
   methods: {

--- a/src/components/layout/FootSection.vue
+++ b/src/components/layout/FootSection.vue
@@ -1,9 +1,12 @@
 <script lang="ts">
+import type { Theme } from "@/utils/enums/theme.enum";
 import { mapActions, mapState } from "pinia";
+
 import { defineComponent } from "vue";
 
 import { useAppStore } from "@/state/stores/app.store";
-import { Theme } from "@/utils/enums/theme.enum";
+
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -29,8 +32,9 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
+
   },
 
   methods: {

--- a/src/components/layout/HeadSection.vue
+++ b/src/components/layout/HeadSection.vue
@@ -13,6 +13,7 @@ import { PageType } from "@/utils/enums/pageType.enum";
 import { Theme } from "@/utils/enums/theme.enum";
 
 import { ModalHelper } from "@/utils/helpers/modal.helper";
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -33,12 +34,30 @@ export default defineComponent({
 
     /**
      * @description
-     * Returns the approprite theme icon
+     * Returns the appropriate theme icon
      *
      * @returns The theme icon name string
      */
     themeIcon(): string {
-      return this.isDark ? "sun" : "moon";
+      if (this.theme === Theme.Auto) {
+        return "circle-half-stroke";
+      }
+
+      if (this.theme === Theme.Dark) {
+        return "sun";
+      }
+
+      return "moon";
+    },
+
+    /**
+     * @description
+     * Checks if dark theme is active (either explicitly or via system preference in Auto mode)
+     *
+     * @returns Whether the dark theme is active
+     */
+    isDark(): boolean {
+      return ThemeHelper.isDark(this.theme as Theme);
     },
 
     /**
@@ -48,18 +67,17 @@ export default defineComponent({
      * @returns The theme tooltip text string
      */
     themeTooltip(): string {
-      return this.isDark ? "Turn Light Mode On" : "Turn Dark Mode On";
+      if (this.theme === Theme.Auto) {
+        return "Turn Light Mode On";
+      }
+
+      if (this.theme === Theme.Light) {
+        return "Turn Dark Mode On";
+      }
+
+      return "Turn Auto Mode On";
     },
 
-    /**
-     * @description
-     * Checks if dark theme is on
-     *
-     * @returns Whether the dark theme is active
-     */
-    isDark(): boolean {
-      return this.theme === Theme.Dark;
-    },
   },
 
   created() {

--- a/src/components/layout/ViewComp.vue
+++ b/src/components/layout/ViewComp.vue
@@ -1,19 +1,21 @@
 <script lang="ts">
+import type { Theme } from "@/utils/enums/theme.enum";
+
 import type { TSource } from "@/utils/types/composition/source.type";
 
 import { mapActions, mapState } from "pinia";
-
 import { defineComponent } from "vue";
+
 import SourceDetail from "@/components/source/SourceDetail.vue";
 
 import { useAppStore } from "@/state/stores/app.store";
-
 import { useSourcesStore } from "@/state/stores/sources.store";
+
 import { PageType } from "@/utils/enums/pageType.enum";
 
-import { Theme } from "@/utils/enums/theme.enum";
 import { DragHelper } from "@/utils/helpers/drag.helper";
 import { ModalHelper } from "@/utils/helpers/modal.helper";
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -70,8 +72,9 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
+
   },
 
   methods: {

--- a/src/components/source/SourceComp.vue
+++ b/src/components/source/SourceComp.vue
@@ -1,15 +1,17 @@
 <script lang="ts">
 import type { PropType } from "vue";
-import type { TSource } from "@/utils/types/composition/source.type";
+import type { Theme } from "@/utils/enums/theme.enum";
 
+import type { TSource } from "@/utils/types/composition/source.type";
 import { mapState } from "pinia";
+
 import { defineComponent, ref } from "vue";
 
 import { useAppStore } from "@/state/stores/app.store";
-import { Theme } from "@/utils/enums/theme.enum";
 
 import { ConfirmHelper } from "@/utils/helpers/confirm.helper";
 import { getVolumeIcon } from "@/utils/helpers/fontawesome.helper";
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -79,7 +81,7 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
 
     /**

--- a/src/components/source/SourceEmpty.vue
+++ b/src/components/source/SourceEmpty.vue
@@ -1,9 +1,12 @@
 <script lang="ts">
+import type { Theme } from "@/utils/enums/theme.enum";
 import { mapState } from "pinia";
+
 import { defineComponent } from "vue";
 
 import { useAppStore } from "@/state/stores/app.store";
-import { Theme } from "@/utils/enums/theme.enum";
+
+import { ThemeHelper } from "@/utils/helpers/theme.helper";
 
 
 
@@ -24,7 +27,7 @@ export default defineComponent({
      * @returns Whether the dark theme is active
      */
     isDark(): boolean {
-      return this.theme === Theme.Dark;
+      return ThemeHelper.isDark(this.theme as Theme);
     },
   },
 

--- a/src/state/effects/app.effect.ts
+++ b/src/state/effects/app.effect.ts
@@ -1,7 +1,6 @@
 import { Theme } from "@/utils/enums/theme.enum";
 
 import { ThemeHelper } from "@/utils/helpers/theme.helper";
-
 import { ToastHelper } from "@/utils/helpers/toast.helper";
 import { useAppStore } from "../stores/app.store";
 
@@ -14,20 +13,27 @@ import { useAppStore } from "../stores/app.store";
 export function hookAppEffect() {
   const appStore = useAppStore();
 
+  // Apply the initial theme on startup and register the system preference listener
+  ThemeHelper.updateTheme(appStore.theme);
+
+  ThemeHelper.setupAutoListener(() => {
+    ThemeHelper.updateTheme(appStore.theme);
+  });
+
   document.documentElement.onfullscreenchange = () => {
     const fullscreen = Boolean(document.fullscreenElement);
 
     appStore.updateFullscreen(fullscreen);
   };
 
-  appStore.$onAction(({ name, store, after, args }) => {
+  appStore.$onAction(({ name, after, args }) => {
     after(() => {
       switch (name) {
         case "updateFullscreen": {
-          if (store.fullscreen && !document.fullscreenElement) {
+          if (appStore.fullscreen && !document.fullscreenElement) {
             document.documentElement.requestFullscreen();
           }
-          else if (!store.fullscreen && document.fullscreenElement) {
+          else if (!appStore.fullscreen && document.fullscreenElement) {
             document.exitFullscreen();
           }
 
@@ -36,10 +42,16 @@ export function hookAppEffect() {
 
         case "updateTheme": {
           const [theme] = args;
-          const message = theme === Theme.Light ? "Light Theme On" : "Dark Theme On";
 
           ThemeHelper.updateTheme(theme);
-          ToastHelper.show({ message });
+
+          const messages: Record<Theme, string> = {
+            [Theme.Auto]: "Auto Theme On",
+            [Theme.Light]: "Light Theme On",
+            [Theme.Dark]: "Dark Theme On",
+          };
+
+          ToastHelper.show({ message: messages[theme as Theme] });
 
           break;
         }

--- a/src/state/stores/app.store.ts
+++ b/src/state/stores/app.store.ts
@@ -10,7 +10,7 @@ export const useAppStore = defineStore("app", {
     seekStep: 10,
     volumeStep: 0.1,
     fullscreen: false,
-    theme: Theme.Light,
+    theme: Theme.Auto,
     hover: {
       head: false,
       foot: false,
@@ -80,14 +80,14 @@ export const useAppStore = defineStore("app", {
 
     /**
      * @description
-     * Toggles the app's theme
+     * Toggles the app's theme (cycles Auto → Light → Dark → Auto)
      */
     toggleTheme(): void {
-      const theme = this.theme === Theme.Light
-        ? Theme.Dark
-        : Theme.Light;
+      const themes = [Theme.Auto, Theme.Light, Theme.Dark];
+      const currentIndex = themes.indexOf(this.theme);
+      const nextTheme = themes[(currentIndex + 1) % themes.length];
 
-      this.updateTheme(theme);
+      this.updateTheme(nextTheme);
     },
 
     /**

--- a/src/utils/enums/theme.enum.ts
+++ b/src/utils/enums/theme.enum.ts
@@ -2,9 +2,15 @@ export enum Theme {
 
   /**
    * @default
+   * Auto mode (follows system preference)
+   */
+  Auto = 0,
+
+  /**
+   * @description
    * Light mode
    */
-  Light = 0,
+  Light,
 
   /**
    * @description

--- a/src/utils/helpers/fontawesome.helper.ts
+++ b/src/utils/helpers/fontawesome.helper.ts
@@ -4,6 +4,7 @@ import {
   faBackward,
   faCheck,
   faChevronDown,
+  faCircleHalfStroke,
   faCircleNotch,
   faCompress,
   faEllipsisVertical,
@@ -63,6 +64,7 @@ export function initIcons(): void {
     faXmark,
     faCheck,
     faPen,
+    faCircleHalfStroke,
     faTriangleExclamation,
   );
 }

--- a/src/utils/helpers/theme.helper.ts
+++ b/src/utils/helpers/theme.helper.ts
@@ -1,4 +1,28 @@
-import type { Theme } from "../enums/theme.enum";
+import { ref } from "vue";
+
+import { Theme } from "../enums/theme.enum";
+
+
+
+/**
+ * @description
+ * The media query string for detecting system dark mode preference
+ */
+const PREFERS_DARK_QUERY = "(prefers-color-scheme: dark)";
+
+/**
+ * @description
+ * The resolved media query list for system dark mode preference
+ */
+const systemDarkQuery = window.matchMedia(PREFERS_DARK_QUERY);
+
+/**
+ * @description
+ * Reactive reference to the system's current dark mode preference.
+ * Updating this ref triggers re-evaluation of any Vue computed
+ * property that reads it (e.g., component-level isDark computeds).
+ */
+const systemDark = ref(systemDarkQuery.matches);
 
 
 
@@ -9,14 +33,65 @@ import type { Theme } from "../enums/theme.enum";
 export class ThemeHelper {
   /**
    * @description
-   * Updates app theme
+   * Returns whether the effective theme resolves to dark,
+   * accounting for Auto mode via the reactive system preference ref.
    *
-   * @param theme The theme to update to
+   * @param theme The theme setting to evaluate
+   * @returns Whether the effective theme is dark
+   */
+  static isDark(theme: Theme): boolean {
+    if (theme === Theme.Dark) {
+      return true;
+    }
+
+    if (theme === Theme.Auto) {
+      return systemDark.value;
+    }
+
+    return false;
+  }
+
+  /**
+   * @description
+   * Returns the system-preferred theme (Light or Dark)
+   *
+   * @returns The system-preferred theme
+   */
+  static getSystemTheme(): Theme {
+    return systemDark.value ? Theme.Dark : Theme.Light;
+  }
+
+  /**
+   * @description
+   * Registers a listener on the system dark mode media query.
+   * Returns a cleanup function to remove the listener.
+   *
+   * @param callback Optional callback invoked when the system preference changes
+   * @returns A function that removes the registered listener
+   */
+  static setupAutoListener(callback?: () => void): () => void {
+    const listener = (e: MediaQueryListEvent): void => {
+      systemDark.value = e.matches;
+      callback?.();
+    };
+
+    systemDarkQuery.addEventListener("change", listener);
+
+    return () => {
+      systemDarkQuery.removeEventListener("change", listener);
+    };
+  }
+
+  /**
+   * @description
+   * Updates the DOM root class to reflect the effective theme
+   *
+   * @param theme The theme to apply
    */
   static updateTheme(theme: Theme): void {
     const root = document.querySelector(":root") as HTMLElement;
 
-    if (theme) {
+    if (ThemeHelper.isDark(theme)) {
       root.classList.add("dark");
     }
     else {


### PR DESCRIPTION
Adds a third theme mode, __Auto__, that automatically follows the operating system's light/dark preference. The theme now cycles __Auto → Light → Dark → Auto__ instead of the previous binary Light ↔ Dark toggle.

---

### Changes

#### `src/utils/enums/theme.enum.ts`

- Added `Auto = 0` as the new default value (bumped `Light` and `Dark` accordingly)

#### `src/utils/helpers/theme.helper.ts`

All theme logic is consolidated here:

- Abstracts the system preference media query behind a named constant (`PREFERS_DARK_QUERY`)
- Holds a module-level reactive Vue `ref` (`systemDark`) initialised from the media query — updating it triggers re-evaluation of every component's `isDark` computed automatically, with no store mutations required
- `isDark(theme)` — resolves the effective dark state for any theme value (explicit or auto)
- `setupAutoListener(callback?)` — registers a `prefers-color-scheme` change listener; returns a cleanup function
- `updateTheme(theme)` — applies or removes the `dark` CSS class on `:root`
- `getSystemTheme()` — returns the resolved `Light` or `Dark` based on current system preference

#### `src/state/stores/app.store.ts`

- Default theme changed to `Theme.Auto`
- `toggleTheme()` now cycles through three values: Auto → Light → Dark → Auto
- No new state fields or actions added — `theme` remains the single source of truth

#### `src/state/effects/app.effect.ts`

- Reduced to a thin coordinator; all theme logic delegated to `ThemeHelper`
- On startup: applies the initial theme and registers the system preference listener
- On `updateTheme` action: syncs the DOM and shows the appropriate toast

#### `src/components/layout/HeadSection.vue`

- Theme button icon cycles: `circle-half-stroke` (Auto) → `moon` (Light) → `sun` (Dark)
- Tooltip cycles: "Turn Light Mode On" → "Turn Dark Mode On" → "Turn Auto Mode On"

#### All other themed components (×13)

- Restored to the original project pattern: `theme` mapped from store + local `isDark` computed via `ThemeHelper.isDark(this.theme)`
- Reactivity for Auto mode is handled transparently through the shared `systemDark` ref in `ThemeHelper` — no per-component wiring needed

---

### How it works

When the OS preference changes while the app is in Auto mode:

1. The `matchMedia` listener updates the `systemDark` Vue `ref` in `ThemeHelper`
2. Vue's reactivity system automatically re-runs every component's `isDark` computed (since they all read `systemDark.value` indirectly via `ThemeHelper.isDark`)
3. The effect's callback re-applies the `dark` CSS class on `:root`

No new store state, no extra subscriptions, no cross-component coupling.

---

### Checklist

- [x] `pnpm lint` passes with zero errors or warnings
- [x] Auto mode reacts live to OS theme changes
- [x] Manual Light and Dark modes work as before
- [x] Theme cycles correctly through all three states


Resolves #168.