### PR TITLE
⏸️ Toast Pause

### DIFF
--- a/src/components/layout/HeadSection.vue
+++ b/src/components/layout/HeadSection.vue
@@ -119,7 +119,7 @@ export default defineComponent({
      * Opens the shortcuts modal
      */
     onShortcuts(): void {
-      ModalHelper.open("Shortcuts", null, ShortcutsComp);
+      ModalHelper.open("Shortcuts", { interrupting: false }, ShortcutsComp);
     },
 
     /**

--- a/src/state/effects/modal.effect.ts
+++ b/src/state/effects/modal.effect.ts
@@ -11,11 +11,16 @@ export function hookModalEffect() {
   const modalStore = useModalStore();
   const sourcesStore = useSourcesStore();
 
-  modalStore.$onAction(({ name, after }) => {
+  modalStore.$onAction(({ name, args, after }) => {
     after(() => {
       switch (name) {
         case "addModal": {
-          sourcesStore.setPlaying(false);
+          const [modal] = args;
+
+          if (modal.params?.interrupting) {
+            sourcesStore.setPlaying(false);
+          }
+
           break;
         }
       }

--- a/src/utils/helpers/modal.helper.ts
+++ b/src/utils/helpers/modal.helper.ts
@@ -25,13 +25,14 @@ export class ModalHelper {
    * @param props The properties to pass to the modal
    * @returns The created modal object
    */
-  private static create<T extends TComponent, U = unknown>(title: string, params: TNullable<TModalParams>, component: InstanceType<T>, props: U): TModal<T, U> {
+  private static create<T extends TComponent, U = unknown>(title: string, params: TNullable<Partial<TModalParams>>, component: InstanceType<T>, props: U): TModal<T, U> {
     const id = v4();
-    const modalParams = params ?? {
-      dialog: true,
-      overlay: true,
-      dismissive: true,
-      alignment: ModalAlignment.Center,
+    const modalParams = {
+      dialog: params?.dialog ?? true,
+      overlay: params?.overlay ?? true,
+      dismissive: params?.dismissive ?? true,
+      interrupting: params?.interrupting ?? true,
+      alignment: params?.alignment ?? ModalAlignment.Center,
     };
 
     return { id, title, component, props, params: modalParams };
@@ -47,7 +48,7 @@ export class ModalHelper {
    * @param props Optional props to pass to the component
    * @returns A promise that resolves with the modal result
    */
-  static open<T extends TComponent, U = { id: string; payload: unknown }, V = unknown>(title: string, params: TNullable<TModalParams>, component: InstanceType<T>, props?: V): Promise<U> {
+  static open<T extends TComponent, U = { id: string; payload: unknown }, V = unknown>(title: string, params: TNullable<Partial<TModalParams>>, component: InstanceType<T>, props?: V): Promise<U> {
     return new Promise((resolve) => {
       const store = useModalStore();
       const modal = this.create(title, params, component, props);

--- a/src/utils/helpers/toast.helper.ts
+++ b/src/utils/helpers/toast.helper.ts
@@ -31,6 +31,7 @@ export class ToastHelper {
         overlay: false,
         dismissive: false,
         alignment: ModalAlignment.Top,
+        interrupting: false,
       };
 
       for (const toast of toasts) {

--- a/src/utils/types/composition/modalParams.type.ts
+++ b/src/utils/types/composition/modalParams.type.ts
@@ -31,4 +31,10 @@ export type TModalParams = {
    * The alignment of the modal
    */
   alignment: ModalAlignment;
+
+  /**
+   * @description
+   * If the modal opening should pause sources playback
+   */
+  interrupting: boolean;
 };


### PR DESCRIPTION
## Problem

Opening a toast notification or the shortcuts modal was incorrectly pausing all source playback. The root cause was in `modal.effect.ts`, which unconditionally called `sourcesStore.setPlaying(false)` on **every** `addModal` action — with no distinction between modals that require user attention (e.g. Add Source, Confirm) and purely informational or transient ones (toasts, shortcuts).

## Solution

Introduced an `interrupting` boolean flag on `TModalParams` that explicitly controls whether opening a modal should pause playback.

- **`interrupting: true`** (default in `ModalHelper`) — Add Source and Confirm dialogs continue to pause sources as intended.
- **`interrupting: false`** — Toasts (non-blocking, transient) and the Shortcuts modal (read-only, informational) no longer interrupt playback.

The effect now guards the pause behind this flag:

```ts
if (modal.params?.interrupting) {
  sourcesStore.setPlaying(false);
}
```

## Files Changed

| File | Change |
|------|--------|
| `src/utils/types/composition/modalParams.type.ts` | Added `interrupting: boolean` to `TModalParams` |
| `src/utils/helpers/modal.helper.ts` | Set `interrupting: true` in the null-params fallback defaults |
| `src/utils/helpers/toast.helper.ts` | Set `interrupting: false` in toast params |
| `src/components/layout/HeadSection.vue` | Pass explicit params with `interrupting: false` for the shortcuts modal |
| `src/state/effects/modal.effect.ts` | Guard `setPlaying(false)` behind `modal.params?.interrupting` |

Fixes #169.