### PR TITLE
 ✂️ Better Cropping

### DIFF
--- a/src/components/layout/ControlsComp.vue
+++ b/src/components/layout/ControlsComp.vue
@@ -42,24 +42,37 @@ export default defineComponent({
 
     /**
      * @description
-     * The universal duration,
-     * generally the duration of the longest source
+     * The universal duration, based on the cropped range (end − start)
+     * of the longest source
      *
-     * @returns The maximum duration in seconds
+     * @returns The maximum cropped duration in seconds
      */
     duration(): number {
-      return Math.max(...this.sources.map(e => e.metadata.duration));
+      if (!this.sources.length) {
+        return 0;
+      }
+
+      return Math.max(...this.sources.map(e => (e.metadata.end || e.metadata.duration) - e.metadata.start));
     },
 
     /**
      * @description
      * Returns the current time of the longest loaded source
-     * to use a a reference for universal time
+     * relative to its start offset, for use as a universal timeline position
      *
-     * @returns The current timeline value in seconds
+     * @returns The current timeline value in seconds (relative to start)
      */
     timelineValue(): number {
-      return this.longestSource?.metadata?.currentTime ?? 0;
+      const source = this.longestSource;
+
+      if (!source) {
+        return 0;
+      }
+
+      const currentTime = source.metadata?.currentTime ?? 0;
+      const start = source.metadata?.start ?? 0;
+
+      return Math.max(0, currentTime - start);
     },
 
     /**

--- a/src/state/stores/sources.store.ts
+++ b/src/state/stores/sources.store.ts
@@ -23,13 +23,16 @@ export const useSourcesStore = defineStore("sources", {
 
     /**
      * @description
-     * Returns the longest source
+     * Returns the source with the longest cropped range (end − start)
      *
      * @param state The current state
      * @returns The longest source object
      */
     longestSource: (state) => {
-      const sortedByLength = state.sources.slice(0).sort((a, b) => b.metadata.duration - a.metadata.duration);
+      const cropped = (s: typeof state.sources[0]) =>
+        (s.metadata.end || s.metadata.duration) - s.metadata.start;
+
+      const sortedByLength = state.sources.slice(0).sort((a, b) => cropped(b) - cropped(a));
 
       return sortedByLength[0] ?? 0;
     },

--- a/src/utils/helpers/source.helper.ts
+++ b/src/utils/helpers/source.helper.ts
@@ -101,9 +101,14 @@ export class SourceHelper {
   static async play(id: string): Promise<void> {
     await this.sync();
     const player = this.getPlayer(id);
+    const store = useSourcesStore();
+    const source = store.getSource(id);
 
-    if (player) {
-      if (player.currentTime < player.duration) {
+    if (player && source) {
+      const end = source.metadata.end || player.duration;
+
+      // Don't restart a source that has already reached its cropped end
+      if (player.currentTime < end - 0.05) {
         player.play();
       }
     }
@@ -133,9 +138,11 @@ export class SourceHelper {
   static async restart(id: string): Promise<void> {
     await this.sync();
     const player = this.getPlayer(id);
+    const store = useSourcesStore();
+    const source = store.getSource(id);
 
-    if (player) {
-      player.currentTime = 0;
+    if (player && source) {
+      player.currentTime = source.metadata.start;
       player.play();
     }
   }
@@ -160,13 +167,18 @@ export class SourceHelper {
    * Seeks a specific time on the timeline
    *
    * @param id The ID of the source
-   * @param time The number of seconds to seek to
+   * @param time The number of seconds to seek (delta)
    */
   static seek(id: string, time: number): void {
     const player = this.getPlayer(id);
+    const store = useSourcesStore();
+    const source = store.getSource(id);
 
-    if (player) {
-      player.currentTime += time;
+    if (player && source) {
+      const start = source.metadata.start;
+      const end = (source.metadata.end || player.duration) - 0.1;
+
+      player.currentTime = MathHelper.clamp(player.currentTime + time, start, end);
     }
   }
 
@@ -175,13 +187,26 @@ export class SourceHelper {
    * Seeks to a specific time on the timeline
    *
    * @param id The ID of the source
-   * @param time The time to seek to
+   * @param time The relative time to seek to (offset from source start)
    */
   static setTime(id: string, time: number): void {
     const player = this.getPlayer(id);
+    const store = useSourcesStore();
+    const source = store.getSource(id);
 
-    if (player) {
-      player.currentTime = Math.min(time, player.duration - 0.1);
+    if (player && source) {
+      const start = source.metadata.start;
+      const end = source.metadata.end || player.duration;
+      const absoluteTime = start + time;
+
+      // If the requested position is at or past this source's end it has
+      // already played its full range — leave it frozen and don't trigger
+      // any buffering/play events that would cause a stutter loop.
+      if (absoluteTime >= end) {
+        return;
+      }
+
+      player.currentTime = MathHelper.clamp(absoluteTime, start, end - 0.1);
     }
   }
 
@@ -280,10 +305,13 @@ export class SourceHelper {
           player.volume = source.metadata.volume;
           player.playbackRate = source.metadata.speed;
 
+          const start = source.metadata.start;
+          const end = source.metadata.end || MathHelper.sanitize(player.duration) || 0;
           const currTime = source.metadata.currentTime;
-          const maxTime = MathHelper.sanitize(player.duration) ?? 0 - 0.1;
 
-          player.currentTime = maxTime > 0 ? Math.min(currTime, maxTime) : currTime;
+          player.currentTime = end > 0
+            ? MathHelper.clamp(currTime, start, end - 0.1)
+            : Math.max(currTime, start);
 
           if (source.metadata.playing) {
             player.play();
@@ -302,7 +330,16 @@ export class SourceHelper {
           };
 
           player.ontimeupdate = () => {
-            store.updateSourceMetadata(id, { currentTime: player.currentTime });
+            const src = store.getSource(id);
+            const end = src?.metadata?.end || player.duration;
+
+            if (player.currentTime >= end) {
+              player.pause();
+              player.currentTime = end - 0.01;
+            }
+            else {
+              store.updateSourceMetadata(id, { currentTime: player.currentTime });
+            }
           };
 
           player.onvolumechange = () => {


### PR DESCRIPTION
## Summary

This PR fixes all known issues with the start/end crop range feature. Previously, the global timeline displayed the full video duration regardless of the crop, scrubbing could move any source outside its cropped window, and sources would play past their set end point. Sources that finished their cropped clip also caused a visible stutter when other longer sources were still playing and the user scrubbed the timeline.

---

## Changes

### `src/components/layout/ControlsComp.vue`

- __`duration` computed__ — now derives from `max(end − start)` across all sources (the effective cropped length) instead of the raw full video duration. The timeline bar now correctly represents only the playable window.
- __`timelineValue` computed__ — now returns `currentTime − start` (position within the cropped window) instead of the absolute video timestamp. The scrub thumb position now maps accurately to the cropped range.

### `src/utils/helpers/source.helper.ts`

- __`setTime(id, relativeTime)`__ — interprets the incoming scrub value as a relative offset from the source's `start`. Computes `absoluteTime = start + relativeTime` and clamps to `[start, end − 0.1]`. If `absoluteTime ≥ end` (the user scrubs past a source that has already finished), the function returns early without touching the player — preventing buffering events that caused the stutter loop.
- __`seek(id, delta)`__ — clamps `currentTime + delta` to `[start, end − 0.1]` so forward/backward seeking cannot escape the cropped range.
- __`play(id)`__ — checks `currentTime < end − 0.05` instead of `player.duration`. The dead-zone ensures buffering-triggered `play()` calls (via `setBufferPause(false)`) never restart a source that is sitting at its end boundary.
- __`restart(id)`__ — resets `currentTime` to `source.metadata.start` instead of `0`, so restart correctly begins at the cropped start point.
- __`hook()` — initial setup__ — clamps `currentTime` to `[start, end − 0.1]` at hook time.
- __`hook()` — `ontimeupdate`__ — enforces the end boundary in real time: when `currentTime ≥ end`, pauses the player and holds it at `end − 0.01`, naturally triggering the `onpause` → `playing: false` store update without affecting other sources.

### `src/state/stores/sources.store.ts`

- __`longestSource` getter__ — now sorts by cropped length `(end || duration) − start` instead of raw `duration`, ensuring the timeline reference source accurately reflects the longest clip window.

---

## Behaviour before / after

| Scenario | Before | After |
|---|---|---|
| Timeline duration display | Full video length | Cropped length (end − start) |
| Scrub thumb position | Absolute video time | Relative to crop start |
| Scrubbing past a source's end | Repositions it inside range → stutter | Source stays frozen at its last frame |
| Playback past end | Plays to video end | Pauses at end |
| Restart | Resets to 0:00 | Resets to cropped start |
| Forward/backward seek | Could escape crop range | Clamped to [start, end] |


Resolves #134.